### PR TITLE
Enable configurable headers for x-* headers

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -8,5 +8,11 @@
   "env": ".env",
   "auth": {
     "path": "./oap_supervisor/security/auth.py:auth"
+  },
+  "http": {
+    "configurable_headers": {
+      "include": ["x-*"],
+      "exclude": ["authorization"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
Configure LangGraph to pass headers with `x-` prefix into runtime config.

## Changes
- Add `http.configurable_headers` configuration to `langgraph.json`
- Include all headers starting with `x-*` (e.g., `x-supabase-access-token`)
- Exclude `authorization` header for security

## Impact
Enables supervisor to receive and utilize custom headers from client requests, allowing proper token propagation to sub-agents for authentication.